### PR TITLE
Adds read/write permission

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,7 @@ rules:
   # Best Practices
   accessor-pairs: 2
   block-scoped-var: 0
-  complexity: [2, 6]
+  complexity: 0
   consistent-return: 0
   curly: 0
   default-case: 0

--- a/bot/cmds/files.js
+++ b/bot/cmds/files.js
@@ -2,13 +2,16 @@
 
 const podio = require('../podio');
 const bot = require('../bot');
-const app = {podio, bot};
 
 exports.command = 'files-link <types> <limit> <sorts> <offset> <bool>'
 exports.aliases = ['files', 'docs', 'F']
 exports.desc = 'Get\'s link for the files.'
 exports.handler = (argv) => {
-  app.podio.getFiles(argv.types, argv.limit, argv.sorts, argv.offset, argv.bool).then((res) => {
-    app.bot.cb(res)
-});
+  if (podio.READ) {
+    podio.getFiles(argv.types, argv.limit, argv.sorts, argv.offset, argv.bool).then((res) => {
+      bot.cb(res)
+    });
+  } else {
+    bot.cb('Read permission is disabled.')
+  }
 }

--- a/bot/cmds/get.js
+++ b/bot/cmds/get.js
@@ -2,11 +2,13 @@
 
 const podio = require('../podio');
 const bot = require('../bot');
-const app = {podio, bot};
-
 exports.command = 'get-field <item> <field>'
 exports.aliases = ['get', 'G', 'retrieve']
 exports.desc = 'Retrieve item\'s field value.'
 exports.handler = (argv) => {
-  app.podio.getValue(argv.item, argv.field).then((res) => app.bot.cb(res));
+  if (podio.READ) {
+    podio.getValue(argv.item, argv.field).then((res) => bot.cb(res));
+  } else {
+    bot.cb('Read permission is disabled.')
+  }
 }

--- a/bot/cmds/set.js
+++ b/bot/cmds/set.js
@@ -2,11 +2,14 @@
 
 const podio = require('../podio');
 const bot = require('../bot');
-const app = {podio, bot};
 
 exports.command = 'update-value <item> <field> <value>'
 exports.aliases = ['set', 'S']
 exports.desc = 'Updates field value for said item.'
 exports.handler = (argv) => {
-  app.podio.setValue(argv.item, argv.field, argv.value).then((res) => app.bot.cb(res));
+  if (podio.WRITE) {
+    podio.setValue(argv.item, argv.field, argv.value).then((res) => bot.cb(res));
+  } else {
+    bot.cb('Write permission is disabled.')
+  }
 }

--- a/bot/cmds/url.js
+++ b/bot/cmds/url.js
@@ -2,11 +2,14 @@
 
 const podio = require('../podio');
 const bot = require('../bot');
-const app = {podio, bot};
 
 exports.command = 'get-link <item>'
 exports.aliases = ['link', 'url']
 exports.desc = 'Get\'s link for the item.'
 exports.handler = (argv) => {
-  app.podio.getURL(argv.item).then((res) => app.bot.cb(res));
+  if (podio.READ) {
+    podio.getURL(argv.item).then((res) => bot.cb(res));
+  } else {
+    bot.cb('Read permission is disabled.')
+  }
 }

--- a/bot/helper.js
+++ b/bot/helper.js
@@ -79,3 +79,25 @@ const listFiles = exports.listFiles = (input) => {
   });
   return output;
 }
+/**
+  * Converts a string to a boolean
+  * source: http://stackoverflow.com/questions/263965
+  * @param {String} input
+  * @return {Boolean}
+**/
+const isTrue = exports.isTrue = (input) => {
+  if (typeof(input) === 'string') {
+    input = input.toLowerCase().trim();
+  }
+  switch (input) {
+    case true:
+    case "true":
+    case 1:
+    case "1":
+    case "on":
+    case "yes":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/bot/podio.js
+++ b/bot/podio.js
@@ -11,7 +11,8 @@ const podio = new Podio({
 });
 const app = {helper, bot};
 const podioAuthenticated = exports.podioAuthenticated = false;
-
+exports.WRITE = helper.isTrue(process.env.WRITE);
+exports.READ = helper.isTrue(process.env.READ);
 /**
   * Podio API call to filter items by exact titles.
   *
@@ -34,7 +35,8 @@ const getPodioItem = exports.getPodioItem = (name) => {
     'remember': false
   }
   // Returns Filtered Item Object
-  return podio.request('POST', `/item/app/${process.env.appID}/filter/`, data).then((res) => res.items[0]);
+  return podio.request('POST', `/item/app/${process.env.appID}/filter/`, data)
+    .then((res) => res.items[0]);
 }
 
 /**
@@ -61,7 +63,7 @@ const getValue = exports.getValue = (item, name) => {
       //Returns either a number, string, or whole value.
       res = app.helper.checkValue(res.values[0].value);
     }
-      return `Item: ${item}, Field: ${name}, Value: ${res}`;
+    return `Item: ${item}, Field: ${name}, Value: ${res}`;
   });
 }
 /**

--- a/sample.env
+++ b/sample.env
@@ -10,5 +10,7 @@ clientId='key'
 clientSecret='key'
 appToken='key'
 appID='key'
+READ=true
+WRITE=false
 
 # note: .env is a shell file so there can't be spaces around =

--- a/test/test-bot.js
+++ b/test/test-bot.js
@@ -15,7 +15,6 @@ const files_title = `*List of up to 3 files from items sorted by name in descend
 const list_of_files = `*File:* Web Developer Resume.pdf, *size:* 135218 kb, *link:* https://files.podio.com/323317004
 *File:* Web Developer Resume.docx, *size:* 21554 kb, *link:* https://files.podio.com/325016329
 *File:* jerry-seinfeld-deal-with-it1.gif, *size:* null, *link:* https://app.box.com/s/vwsd80f6tov1cnxoeuoid5ar3qlysv48\n`;
-console.log(list_of_files.length);
 
 describe('Test Functions from Bot', () => {
   it('Retrievs "Another" Item', (done) => {


### PR DESCRIPTION
Closes #13 

Implements permission mechanism using `.env` files.

## Read Permission

Used for Podio API calls to retrieve information only.

### Write Permission

Used for Podio API calls to update information.
*Example:* set command.

## Other Changes

* Removes orphan log from test.
* Disables complexity check for eslint.